### PR TITLE
feat(auth): add POC for supporting token authentication

### DIFF
--- a/client.go
+++ b/client.go
@@ -33,20 +33,35 @@ func Null(roundTripper http.RoundTripper) *Client {
 	}
 }
 
-func NewClient(team string) (*Client, error) {
-	auth, err := GetAuth(team)
-	if err != nil {
-		return nil, err
-	}
-
-	c := &Client{
-		team: team,
-		auth: auth,
-
+func NewClient(team string) *Client {
+	return &Client{
+		team:       team,
 		httpClient: http.DefaultClient,
 	}
+}
 
-	return c, nil
+func (c *Client) WithCookieAuth() error {
+	auth, err := GetCookieAuth(c.team)
+
+	if err != nil {
+		return err
+	}
+
+	c.auth = auth
+	fmt.Printf("%+v\n", auth)
+	return nil
+}
+
+func (c *Client) WithTokenAuth(team string) error {
+	auth, err := GetTokenAuth(team)
+
+	if err != nil {
+		return err
+	}
+
+	c.auth = auth
+	fmt.Printf("%+v\n", auth)
+	return nil
 }
 
 func (c *Client) API(ctx context.Context, verb, path string, params map[string]string, body []byte) ([]byte, error) {

--- a/token.go
+++ b/token.go
@@ -18,7 +18,7 @@ type Auth struct {
 	Cookies map[string]string
 }
 
-func GetAuth(team string) (*Auth, error) {
+func GetCookieAuth(team string) (*Auth, error) {
 	cookie, err := config.GetCookie()
 	if err != nil {
 		return nil, err
@@ -51,4 +51,8 @@ func GetAuth(team string) (*Auth, error) {
 	}
 
 	return &Auth{Token: string(matches[1]), Cookies: map[string]string{"d": cookie}}, nil
+}
+
+func GetTokenAuth(token string) (*Auth, error) {
+	return &Auth{Token: token}, nil
 }


### PR DESCRIPTION
This is only a POC for now.

`GetAuthToken` was not confirmed to work as I don't have a slack-app handy at the moment.

However, looking at [the doc](https://api.slack.com/authentication/token-types), it should work with properly configured Bot, Users, and App-level token _without_ any additional cookie.

E.g. usage:

```go
package main

import (
	"context"
	"fmt"

	slack "github.com/rneatherway/slackclient"
)

func main() {
	c := slack.NewClient("example")

	// this
	if err := c.WithCookieAuth(); err != nil {
		panic(err)
	}

	// or that
	if err := c.WithTokenAuth("xox..."); err != nil {
		panic(err)
	}

	response, err := c.API(context.Background(),
		"POST",
		"chat.postMessage",
		nil,
		[]byte("{\"channel\":\"nobe4-test-room\",\"text\":\"test\"}"),
	)
	fmt.Println(string(response), err)
}
```

cc https://github.com/rneatherway/gh-slack/pull/57