### PR TITLE
feat(http_client): allow setting a custom httpClient

### DIFF
--- a/client.go
+++ b/client.go
@@ -49,6 +49,10 @@ func NewClient(team string) (*Client, error) {
 	return c, nil
 }
 
+func (c *Client) WithHttpClient(httpClient *http.Client) {
+	c.httpClient = httpClient
+}
+
 func (c *Client) API(ctx context.Context, verb, path string, params map[string]string, body []byte) ([]byte, error) {
 	u, err := url.Parse(fmt.Sprintf("https://%s.slack.com/api/", c.team))
 	if err != nil {


### PR DESCRIPTION
This implements the idea discussed in https://github.com/rneatherway/gh-slack/pull/57#issuecomment-1892849168

> An addition of a `WithHTTPClient(...)` method would then allow providing the stub RoundTripper.



cc https://github.com/rneatherway/gh-slack/pull/57