### PR TITLE
fix(cookie): remove domain hash prefix

### DIFF
--- a/internal/config/cookie.go
+++ b/internal/config/cookie.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -9,7 +10,20 @@ import (
 	"runtime"
 )
 
-var stmt = "SELECT value, encrypted_value FROM cookies WHERE host_key=\".slack.com\" AND name=\"d\""
+var (
+	stmt = `SELECT value, encrypted_value FROM cookies WHERE host_key=".slack.com" AND name="d"`
+
+	// Chromium prefixes the encrypted value with a SHA256 hash of the domain
+	// name. Once the value is decrypted, we must remove the hash to get the
+	// cookie value back.
+	// See https://chromium-review.googlesource.com/c/chromium/src/+/5792044
+	prefixes = [][]byte{
+		// slack.com
+		{3, 202, 236, 172, 132, 247, 212, 240, 217, 211, 68, 226, 103, 153, 245, 64, 85, 68, 2, 183, 83, 182, 186, 218, 14, 102, 237, 62, 231, 241, 231, 142},
+		// .slack.com
+		{145, 28, 115, 68, 173, 92, 42, 78, 104, 243, 5, 63, 24, 206, 51, 190, 31, 169, 160, 244, 247, 106, 147, 228, 60, 68, 92, 134, 105, 199, 162, 120},
+	}
+)
 
 type CookieDecryptor interface {
 	Decrypt(value, key []byte) ([]byte, error)
@@ -26,6 +40,16 @@ func decrypt(encryptedValue, key []byte) ([]byte, error) {
 	default:
 		panic(fmt.Sprintf("platform %q not supported", runtime.GOOS))
 	}
+}
+
+func removeDomainHashPrefix(value []byte) []byte {
+	for _, prefix := range prefixes {
+		if bytes.HasPrefix(value, prefix) {
+			return value[len(prefix):]
+		}
+	}
+
+	return value
 }
 
 func GetCookie() (string, error) {
@@ -75,6 +99,8 @@ func GetCookie() (string, error) {
 	if err != nil {
 		return "", err
 	}
+
+	decryptedValue = removeDomainHashPrefix(decryptedValue)
 
 	return string(decryptedValue), err
 }


### PR DESCRIPTION
In https://github.com/rneatherway/gh-slack/issues/71 it was discussed and discovered that some versions of Slack now include a SHA256 of the host name as a prefix of the cookie.

This makes the cookie value invalid as-is, and the cookie value needs to be trimmed from the hash before being used.

Using `-tag network` I was able to run the test locally and confirmed that this now works.

Fix https://github.com/rneatherway/gh-slack/issues/71 

cc https://github.com/nobe4/gh-slack/pull/1
cc https://github.com/rneatherway/slack/pull/5